### PR TITLE
Removed use of ".pop()" in selecting inputs - caused error in async running

### DIFF
--- a/ukcp_dp/_input_data.py
+++ b/ukcp_dp/_input_data.py
@@ -223,7 +223,9 @@ class InputData(object):
         if type(area) is list:
             # this will be a bbox or point, i.e.
             # ['point',430311.27,253673.63]
-            area_type = area.pop(0)
+            # First value will be area type
+            area_type = area[0]
+            area = area[1:]
 
             if (area_type not in
                     [AreaType.BBOX, AreaType.POINT, AreaType.COAST_POINT,


### PR DESCRIPTION
This meant that the async run was failing because the pickle file containing the inputs had an incorrect "area" input. 

This fix avoids using ".pop()" when setting the area/areatype and solves this problem.

@antony-wilson : please review and accept and merge.